### PR TITLE
Add Stripe integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY= (Optional)
+STRIPE_SECRET_KEY= (Your Stripe secret key)
 ```
+
+### Stripe Payments
+
+Payments processed through the application use Stripe. The default payee email
+is `cnye@ai-automated.xyz`. Configure `STRIPE_SECRET_KEY` with your Stripe
+secret key to enable checkout sessions.
 
 4. Run the development server
 `pnpm dev`

--- a/app/api/stripe/route.ts
+++ b/app/api/stripe/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createCheckoutSession } from "@/lib/stripe";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { amount, currency = "usd", description } = await request.json();
+
+    if (!amount) {
+      return NextResponse.json({ error: "Amount is required" }, { status: 400 });
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+
+    const session = await createCheckoutSession({
+      amount,
+      currency,
+      description,
+      successUrl: `${baseUrl}/payment/success`,
+      cancelUrl: `${baseUrl}/payment/cancel`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (error) {
+    console.error("Stripe integration error:", error);
+    return NextResponse.json(
+      { error: "Failed to create checkout session" },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,41 @@
+export const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || 'sk_test_placeholder';
+
+export const PAYEE_EMAIL = 'cnye@ai-automated.xyz';
+
+export const STRIPE_API_BASE = 'https://api.stripe.com/v1';
+
+interface CheckoutSessionParams {
+  amount: number;
+  currency: string;
+  description?: string;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+export async function createCheckoutSession(params: CheckoutSessionParams) {
+  const body = new URLSearchParams();
+  body.append('payment_method_types[]', 'card');
+  body.append('line_items[0][price_data][currency]', params.currency);
+  body.append('line_items[0][price_data][product_data][name]', params.description || 'Payment');
+  body.append('line_items[0][price_data][unit_amount]', params.amount.toString());
+  body.append('line_items[0][quantity]', '1');
+  body.append('mode', 'payment');
+  body.append('success_url', params.successUrl);
+  body.append('cancel_url', params.cancelUrl);
+  body.append('metadata[payee]', PAYEE_EMAIL);
+
+  const res = await fetch(`${STRIPE_API_BASE}/checkout/sessions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${STRIPE_SECRET_KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to create checkout session');
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- enable Stripe payment logic via new library
- expose POST `/api/stripe` endpoint to start checkout sessions
- document Stripe environment variable

## Testing
- `pnpm lint` *(fails: Unknown options)*

------
https://chatgpt.com/codex/tasks/task_e_687ee994b56083318d65820adcf7df35