### PR TITLE
Enable file uploads in chat

### DIFF
--- a/app/api/chat-files/route.ts
+++ b/app/api/chat-files/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/supabase/server";
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file") as File;
+    if (!file) {
+      return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const fileName = `${Date.now()}-${file.name}`;
+    const filePath = `${user.id}/${fileName}`;
+
+    const { error: uploadError } = await supabase.storage
+      .from("chat-files")
+      .upload(filePath, file);
+
+    if (uploadError) {
+      console.error("Error uploading chat file:", uploadError);
+      return NextResponse.json({ error: "Failed to upload" }, { status: 500 });
+    }
+
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from("chat-files").getPublicUrl(filePath);
+
+    return NextResponse.json({ url: publicUrl });
+  } catch (err) {
+    console.error("Unexpected error uploading file:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/components/chat/MessageInput.tsx
+++ b/components/chat/MessageInput.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { useState, useRef, useEffect, FormEvent, KeyboardEvent } from "react";
-import { Send } from "lucide-react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  FormEvent,
+  KeyboardEvent,
+} from "react";
+import { Send, Paperclip, X } from "lucide-react";
 
 interface MessageInputProps {
   onSend: (message: string) => void;
@@ -10,7 +16,9 @@ interface MessageInputProps {
 
 export default function MessageInput({ onSend, disabled }: MessageInputProps) {
   const [message, setMessage] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -27,15 +35,59 @@ export default function MessageInput({ onSend, disabled }: MessageInputProps) {
     }
   }, [disabled]);
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      setFiles(Array.from(e.target.files));
+      // reset to allow same file reselect
+      e.target.value = "";
+    }
+  };
+
+  const removeFile = (index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (message.trim() && !disabled) {
-      onSend(message.trim());
-      setMessage("");
-      if (textareaRef.current) {
-        textareaRef.current.style.height = "44px";
-        textareaRef.current.focus();
+    if (disabled || (!message.trim() && files.length === 0)) return;
+
+    let finalMessage = message.trim();
+
+    if (files.length > 0) {
+      for (const file of files) {
+        const formData = new FormData();
+        formData.append("file", file);
+
+        try {
+          const res = await fetch("/api/chat-files", {
+            method: "POST",
+            body: formData,
+          });
+
+          if (res.ok) {
+            const data = await res.json();
+            if (data.url) {
+              finalMessage += `\n[${file.name}](${data.url})`;
+            }
+          }
+        } catch (err) {
+          console.error("File upload failed", err);
+        }
       }
+    }
+
+    if (finalMessage) {
+      onSend(finalMessage);
+    }
+
+    setMessage("");
+    setFiles([]);
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "44px";
+      textareaRef.current.focus();
+    }
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
     }
   };
 
@@ -70,14 +122,50 @@ export default function MessageInput({ onSend, disabled }: MessageInputProps) {
           />
           <button
             type="submit"
-            disabled={!message.trim() || disabled}
+            disabled={(!message.trim() && files.length === 0) || disabled}
             className="absolute right-1.5 sm:right-2 bottom-1.5 sm:bottom-2 p-1.5 sm:p-2 text-blue-500 hover:text-blue-600 disabled:opacity-50 rounded-md hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
             aria-label="Send message"
           >
             <Send className="h-4 w-4 sm:h-5 sm:w-5" />
           </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            onChange={handleFileChange}
+            className="hidden"
+            id="chat-file-input"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled}
+            className="absolute right-10 bottom-1.5 sm:right-11 sm:bottom-2 p-1.5 sm:p-2 text-muted-foreground hover:text-foreground disabled:opacity-50"
+            aria-label="Attach file"
+          >
+            <Paperclip className="h-4 w-4 sm:h-5 sm:w-5" />
+          </button>
         </div>
       </div>
+      {files.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {files.map((file, index) => (
+            <div
+              key={index}
+              className="flex items-center bg-muted rounded px-2 py-1 text-sm"
+            >
+              <span className="mr-1 truncate max-w-[10rem]">{file.name}</span>
+              <button
+                type="button"
+                onClick={() => removeFile(index)}
+                className="ml-1 text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
     </form>
   );
 }

--- a/supabase/migrations/20250729150000_add_chat_files_bucket.sql
+++ b/supabase/migrations/20250729150000_add_chat_files_bucket.sql
@@ -1,0 +1,29 @@
+-- Create chat files bucket
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('chat-files', 'chat-files', true);
+
+-- Set up security policies for chat files bucket
+CREATE POLICY "Chat files are publicly accessible"
+ON storage.objects FOR SELECT
+USING (bucket_id = 'chat-files');
+
+CREATE POLICY "Users can upload their own chat files"
+ON storage.objects FOR INSERT
+WITH CHECK (
+  bucket_id = 'chat-files'
+  AND auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can update their own chat files"
+ON storage.objects FOR UPDATE
+WITH CHECK (
+  bucket_id = 'chat-files'
+  AND auth.uid()::text = (storage.foldername(name))[1]
+);
+
+CREATE POLICY "Users can delete their own chat files"
+ON storage.objects FOR DELETE
+USING (
+  bucket_id = 'chat-files'
+  AND auth.uid()::text = (storage.foldername(name))[1]
+);


### PR DESCRIPTION
## Summary
- allow attaching files when sending a message
- store uploaded files under `chat-files` bucket via new API
- create migration to add `chat-files` storage bucket

## Testing
- `pnpm lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_687ef12a72ac8331b6f8883d60cce1a9